### PR TITLE
Ajustes nas Dependências

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-/target/
-/build/
+target/
+build/
+MANIFEST.MF

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>
@@ -110,12 +112,13 @@
 
 
 		<!-- PrimeFaces (biblioteca de componentes) -->
+		<!-- https://mvnrepository.com/artifact/org.primefaces/primefaces -->
 		<dependency>
-			<groupId>org.primefaces</groupId>
-			<artifactId>primefaces</artifactId>
-			<version>6.1</version>
-			<scope>compile</scope>
+		    <groupId>org.primefaces</groupId>
+		    <artifactId>primefaces</artifactId>
+		    <version>6.1</version>
 		</dependency>
+
 
 		<dependency>
 			<groupId>org.primefaces.extensions</groupId>

--- a/src/main/java/com/aggb/util/jpa/EntityManagerProducer.java
+++ b/src/main/java/com/aggb/util/jpa/EntityManagerProducer.java
@@ -19,13 +19,13 @@ public class EntityManagerProducer {
 	public EntityManagerProducer() {
 		factory = Persistence.createEntityManagerFactory("GerenciadorAcesso");
 	}
-	
-	@Produces @RequestScoped
+	@Produces 
+	@RequestScoped
 	public EntityManager createEntityManager() {
 		return (Session) factory.createEntityManager();
 	}
 	
-	public void closeEntityManager(@Disposes Session manager) {
+	public void closeEntityManager(Session manager) {
 		manager.close();
 	}
 


### PR DESCRIPTION
- Adicionadas algumas pastas ao .gitignore para que não sejam encaminhadas nos commits.
- Adicionado ao pom.xml configurações de compilador e dependência do primefaces que é encontrada no repositório maven.
- Ajustes no EntityManager para que a injeção de dependência funcione.

Todas as alterações tiveram sucesso no servidor JBoss Wildfly 9.